### PR TITLE
fix for "Missing error message" exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function Plugin(configPath, options) {
           });
         file.contents = new Buffer(output);
       } catch (err) {
-        this.emit('error', new PluginError(PLUGIN_NAME, err));
+        this.emit('error', new PluginError(PLUGIN_NAME, '' + file.path + '\n' + err));
       }
     }
 


### PR DESCRIPTION
PluginError expects the second parameter is a string of error message