### PR TITLE
Allow override of syntax with options

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function Plugin(configPath, options) {
       try {
         var output = comb.processString(
           file.contents.toString('utf8'), {
-            syntax: syntax,
+            syntax: options.syntax || syntax,
             filename: file.path
           });
         file.contents = new Buffer(output);


### PR DESCRIPTION
We use postcss to generate our project's CSS - but like to have csscomb run on the input so it's nice an consistent across files. This means we have `.css` files that are more like sass files - so would like to override the syntax csscomb uses.

This PR just pipes the option down to comb.