### PR TITLE
Require "csscomb": "^4.0.1" as a devDependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,12 +62,14 @@ function Plugin(configPath, options) {
       var syntax = options.syntax || file.path.split('.').pop();
 
       try {
-        var output = comb.processString(
+        var promisedOutput = comb.processString(
           file.contents.toString('utf8'), {
             syntax: syntax,
             filename: file.path
           });
-        file.contents = new Buffer(output);
+          promisedOutput.then(processedString => {
+            file.contents = new Buffer(processedString);
+          });
       } catch (err) {
         this.emit('error', new PluginError(PLUGIN_NAME, file.path + '\n' + err));
       }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "index.js"
   ],
   "dependencies": {
-    "csscomb": "^3.1.7",
     "gulp-util": "^3.0.7",
     "through2": "^2.0.1"
   },
   "devDependencies": {
+    "csscomb": "^4.0.1",
     "jshint": "^2.9.3",
     "mocha": "^3.0.2"
   },


### PR DESCRIPTION
Please, add devDependency for the latest csscomb as the current version of csscomb lacks some useful features.